### PR TITLE
dockerize sc2 images and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 # Pydev project settings
 .pydevproject
 
+# Phase1 temp files
+hurdle?/*.dat
+hurdle?/*.bin
+hurdle?/*.json

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,11 @@
+HUBFOLDER ?= itsb
+
+all: base phase1
+
+base:
+	docker build -t $(HUBFOLDER)/sc2:$@ ./$@
+
+phase1: base
+	docker build -t $(HUBFOLDER)/sc2:$@ ./$@
+
+.PHONY: all base phase1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+# Docker images for SC2
+
+## pull pre-build images from [Docker Hub](https://hub.docker.com/r/itsb/sc2/)
+
+    docker pull -a itsb/sc2
+
+## or build images from local Dockerfiles
+
+    make

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:trusty
+
+# update container packages
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y python2.7 python-pip python-dev python-tk git python-thrift && \
+    # missing dependency for matplotlib pip install
+    apt-get install -y libxft-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip
+# install other hurdle dependencies
+RUN pip install jupyter numpy matplotlib
+
+# install gnuradio
+RUN apt-get update && \
+    pip install PyBOMBS && \
+    pybombs recipes add gr-recipes git+https://github.com/gnuradio/gr-recipes.git && \
+    pybombs recipes add gr-etcetera git+https://github.com/gnuradio/gr-etcetera.git && \
+    pybombs config keep_builddir False && \
+    pybombs prefix init /usr/local -a sys -R gnuradio-default && \
+    # clear out build files to shrink image size
+    rm -rf /usr/local/src/gnuradio/build /usr/local/src/uhd/host/build && \
+    # clear package lists
+    rm -rf /var/lib/apt/lists/*

--- a/docker/phase1/Dockerfile
+++ b/docker/phase1/Dockerfile
@@ -1,0 +1,15 @@
+FROM itsb/sc2:base
+
+ENV REPOSITORY_URL=https://github.com/SpectrumCollaborationChallenge/phase1-hurdles.git
+
+# clone hurdle repository into container
+RUN git clone --recursive $REPOSITORY_URL /phase1-hurdles && \
+    # build hurdle 1 support code
+    mkdir /phase1-hurdles/hurdle1/gr-hurdle1/build && \
+    cd /phase1-hurdles/hurdle1/gr-hurdle1/build && \
+    cmake ../ && \
+    make && \
+    make install && \
+    ldconfig
+
+WORKDIR /phase1-hurdles

--- a/hurdle1/README.md
+++ b/hurdle1/README.md
@@ -1,0 +1,10 @@
+Use docker-compose orchestration to start both scoring and solution containers and coordinate their communication.
+See [docker-compose.yaml](docker-compose.yaml) for details.
+
+## Execute stub solution example using docker-compose
+
+    docker-compose up
+
+## Tear down docker-compose service
+
+    docker-compose down

--- a/hurdle1/docker-compose.yaml
+++ b/hurdle1/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  scoring:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle1
+    command: bash -c "./hurdle_1.py --host=0.0.0.0 && ./calc_ber.py --truth-name=truth.bin --decoded-name=rx_packets.bin"
+    volumes:
+    - .:/phase1-hurdles/hurdle1
+    networks:
+      net:
+        ipv4_address: 172.16.251.10
+
+  solution:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle1
+    command: bash -c "sleep 10 && ./hurdle_1_solution_stub.py --host=172.16.251.10"
+    volumes:
+    - .:/phase1-hurdles/hurdle1
+    networks:
+      net:
+        ipv4_address: 172.16.251.11
+
+networks:
+  net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.251.0/24
+        gateway: 172.16.251.1

--- a/hurdle2/README.md
+++ b/hurdle2/README.md
@@ -1,0 +1,10 @@
+Use docker-compose orchestration to start both scoring and solution containers and coordinate their communication.
+See [docker-compose.yaml](docker-compose.yaml) for details.
+
+## Execute stub solution example using docker-compose
+
+    docker-compose up
+
+## Tear down docker-compose service
+
+    docker-compose down

--- a/hurdle2/docker-compose.yaml
+++ b/hurdle2/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  scoring:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle2
+    command: ./run_hurdle2.py
+    volumes:
+    - .:/phase1-hurdles/hurdle2
+    networks:
+      net:
+        ipv4_address: 172.16.252.10
+
+  solution:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle2
+    command: bash -c "sleep 5 && ./hurdle2_solution_stub_edited.py --hurdle2-scoring-host=172.16.252.10"
+    volumes:
+    - .:/phase1-hurdles/hurdle2
+    networks:
+      net:
+        ipv4_address: 172.16.252.11
+
+networks:
+  net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.252.0/24
+        gateway: 172.16.252.1

--- a/hurdle3/README.md
+++ b/hurdle3/README.md
@@ -1,0 +1,10 @@
+Use docker-compose orchestration to start both scoring and solution containers and coordinate their communication.
+See [docker-compose.yaml](docker-compose.yaml) for details.
+
+## Execute stub solution example using docker-compose
+
+    docker-compose up
+
+## Tear down docker-compose service
+
+    docker-compose down

--- a/hurdle3/docker-compose.yaml
+++ b/hurdle3/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: '2'
+
+services:
+  scoring:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle3
+    command: bash -c "sleep 5 && ./Hurdle3Scoring.py --host=172.16.253.11"
+    volumes:
+    - .:/phase1-hurdles/hurdle3
+    networks:
+      net:
+        ipv4_address: 172.16.253.10
+
+  solution:
+    image: itsb/sc2:phase1
+    working_dir: /phase1-hurdles/hurdle3
+    command: ./Hurdle3SolutionServer.py
+    volumes:
+    - .:/phase1-hurdles/hurdle3
+    networks:
+      net:
+        ipv4_address: 172.16.253.11
+
+networks:
+  net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.253.0/24
+        gateway: 172.16.253.1


### PR DESCRIPTION
We were promised Docker images [here](https://spectrumcollaborationchallenge.com/wp-content/uploads/Entrance-Hurdles-Revision1.pdf), but instead were delivered an LXC-based container system.
Docker images and runtime orchestration examples in this PR. Much easier to use than LXC, and  cross-platform friendly.
All this was developed on MacOS using Docker for Mac and confirmed to work on Ubuntu 14.04 as well as Windows 10 with Docker for Windows.
It is my hope that Docker will be officially supported for SC2 phase1 and beyond.
See READMEs in docker and hurdle[123] folders.

NOTES
- LXC containers were nearly identical for all 3 hurdles and identical for scoring vs. solution variants so I consolidated these into a single docker image sc2:phase1 that is a superset of all 3 LXC containers.
- It takes about 42 minutes to build the image from the docker on a powerful server, therefore I recommend most users pull the images from Docker Hub.